### PR TITLE
DSE 705 reduce fb data request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,17 @@ dist
 
 # Keystore
 *.keystore
+
+# VS Code and Metals
+.bloop
+.metals
+.vscode
+project/metals.sbt
+
+# .swp files
+*.swp
+
+# IntelliJ files
+*.iml
+
+

--- a/dataplug-facebook/conf/application.test.conf
+++ b/dataplug-facebook/conf/application.test.conf
@@ -45,7 +45,7 @@ silhouette {
   facebook.clientID = ${?FACEBOOK_CLIENT_ID}
   facebook.clientSecret = ""
   facebook.clientSecret = ${?FACEBOOK_CLIENT_SECRET}
-  facebook.scope = "email,default,user_friends,user_gender,user_link,user_posts"
+  facebook.scope = "public_profile,email,default,user_friends,user_gender,user_link,user_posts"
 
   # Google provider
   google {

--- a/dataplug-facebook/conf/application.test.conf
+++ b/dataplug-facebook/conf/application.test.conf
@@ -5,7 +5,7 @@ silhouette {
   # Authenticator settings
   authenticator.cookieName = "authenticator"
   authenticator.cookiePath = "/"
-  authenticator.secureCookie = false // Disabled for testing on localhost without SSL, otherwise cookie couldn't be set
+  authenticator.secureCookie = false // Disabled for testing on localhost without SSL, otherwise cookie could not be set
   authenticator.httpOnlyCookie = true
   authenticator.useFingerprinting = true
   authenticator.authenticatorIdleTimeout = 30 minutes
@@ -21,7 +21,7 @@ silhouette {
   # OAuth1 token secret provider settings
   oauth1TokenSecretProvider.cookieName = "OAuth1TokenSecret"
   oauth1TokenSecretProvider.cookiePath = "/"
-  oauth1TokenSecretProvider.secureCookie = false // Disabled for testing on localhost without SSL, otherwise cookie couldn't be set
+  oauth1TokenSecretProvider.secureCookie = false // Disabled for testing on localhost without SSL, otherwise cookie could not be set
   oauth1TokenSecretProvider.httpOnlyCookie = true
   oauth1TokenSecretProvider.expirationTime = 5 minutes
 
@@ -31,7 +31,7 @@ silhouette {
   # OAuth2 state provider settings
   oauth2StateProvider.cookieName = "OAuth2State"
   oauth2StateProvider.cookiePath = "/"
-  oauth2StateProvider.secureCookie = false // Disabled for testing on localhost without SSL, otherwise cookie couldn't be set
+  oauth2StateProvider.secureCookie = false // Disabled for testing on localhost without SSL, otherwise cookie could not be set
   oauth2StateProvider.httpOnlyCookie = true
   oauth2StateProvider.expirationTime = 5 minutes
 
@@ -45,7 +45,7 @@ silhouette {
   facebook.clientID = ${?FACEBOOK_CLIENT_ID}
   facebook.clientSecret = ""
   facebook.clientSecret = ${?FACEBOOK_CLIENT_SECRET}
-  facebook.scope = "public_profile,user_friends,user_events,user_posts,email,user_age_range,user_link,user_birthday,user_gender,user_likes"
+  facebook.scope = "email,default,user_friends,user_gender,user_link,user_posts"
 
   # Google provider
   google {

--- a/dataplug-facebook/conf/silhouette.conf
+++ b/dataplug-facebook/conf/silhouette.conf
@@ -3,7 +3,7 @@ silhouette {
   # Authenticator settings
   authenticator.cookieName="authenticator"
   authenticator.cookiePath="/"
-  authenticator.secureCookie=false // Disabled for testing on localhost without SSL, otherwise cookie couldn't be set
+  authenticator.secureCookie=false // Disabled for testing on localhost without SSL, otherwise cookie could not be set
   authenticator.httpOnlyCookie=true
   authenticator.useFingerprinting=true
   authenticator.authenticatorIdleTimeout=30 minutes
@@ -20,7 +20,7 @@ silhouette {
   # OAuth1 token secret provider settings
   oauth1TokenSecretProvider.cookieName="OAuth1TokenSecret"
   oauth1TokenSecretProvider.cookiePath="/"
-  oauth1TokenSecretProvider.secureCookie=false // Disabled for testing on localhost without SSL, otherwise cookie couldn't be set
+  oauth1TokenSecretProvider.secureCookie=false // Disabled for testing on localhost without SSL, otherwise cookie could not be set
   oauth1TokenSecretProvider.httpOnlyCookie=true
   oauth1TokenSecretProvider.expirationTime=5 minutes
 
@@ -33,7 +33,7 @@ silhouette {
   # CSRF state item handler settings
   csrfStateItemHandler.cookieName="OAuth2State"
   csrfStateItemHandler.cookiePath="/"
-  csrfStateItemHandler.secureCookie=false // Disabled for testing on localhost without SSL, otherwise cookie couldn't be set
+  csrfStateItemHandler.secureCookie=false // Disabled for testing on localhost without SSL, otherwise cookie could not be set
   csrfStateItemHandler.httpOnlyCookie=true
   csrfStateItemHandler.expirationTime=5 minutes
 
@@ -51,5 +51,5 @@ silhouette {
   facebook.clientSecret = ""
   facebook.redirectURL = ${?FACEBOOK_CLIENT_SECRET}
   facebook.clientSecret = ${?API_CLIENT_SECRET}
-  facebook.scope = "public_profile,user_friends,user_events,user_posts,email,user_age_range,user_link,user_gender"
+  facebook.scope = "email,default,user_friends,user_gender,user_link,user_posts"
 }

--- a/dataplug-facebook/conf/silhouette.conf
+++ b/dataplug-facebook/conf/silhouette.conf
@@ -51,5 +51,5 @@ silhouette {
   facebook.clientSecret = ""
   facebook.redirectURL = ${?FACEBOOK_CLIENT_SECRET}
   facebook.clientSecret = ${?API_CLIENT_SECRET}
-  facebook.scope = "email,default,user_friends,user_gender,user_link,user_posts"
+  facebook.scope = "public_profile,email,default,user_friends,user_gender,user_link,user_posts"
 }

--- a/dataplug-facebook/conf/silhouette.staging.conf
+++ b/dataplug-facebook/conf/silhouette.staging.conf
@@ -51,5 +51,5 @@ silhouette {
   facebook.clientSecret = ""
   facebook.redirectURL = ${?FACEBOOK_CLIENT_SECRET}
   facebook.clientSecret = ${?API_CLIENT_SECRET}
-  facebook.scope = "public_profile,email,default,user_friends,user_gender,user_link,user_posts"
+  facebook.scope = "public_profile,user_friends,user_events,user_posts,email,user_age_range,user_link,user_gender,user_likes,user_birthday,user_location,user_photos,manage_pages"
 }

--- a/dataplug-facebook/conf/silhouette.staging.conf
+++ b/dataplug-facebook/conf/silhouette.staging.conf
@@ -51,5 +51,5 @@ silhouette {
   facebook.clientSecret = ""
   facebook.redirectURL = ${?FACEBOOK_CLIENT_SECRET}
   facebook.clientSecret = ${?API_CLIENT_SECRET}
-  facebook.scope = "email,default,user_friends,user_gender,user_link,user_posts"
+  facebook.scope = "public_profile,email,default,user_friends,user_gender,user_link,user_posts"
 }

--- a/dataplug-facebook/conf/silhouette.staging.conf
+++ b/dataplug-facebook/conf/silhouette.staging.conf
@@ -3,7 +3,7 @@ silhouette {
   # Authenticator settings
   authenticator.cookieName="authenticator"
   authenticator.cookiePath="/"
-  authenticator.secureCookie=false // Disabled for testing on localhost without SSL, otherwise cookie couldn't be set
+  authenticator.secureCookie=false // Disabled for testing on localhost without SSL, otherwise cookie could not be set
   authenticator.httpOnlyCookie=true
   authenticator.useFingerprinting=true
   authenticator.authenticatorIdleTimeout=30 minutes
@@ -20,7 +20,7 @@ silhouette {
   # OAuth1 token secret provider settings
   oauth1TokenSecretProvider.cookieName="OAuth1TokenSecret"
   oauth1TokenSecretProvider.cookiePath="/"
-  oauth1TokenSecretProvider.secureCookie=false // Disabled for testing on localhost without SSL, otherwise cookie couldn't be set
+  oauth1TokenSecretProvider.secureCookie=false // Disabled for testing on localhost without SSL, otherwise cookie could not be set
   oauth1TokenSecretProvider.httpOnlyCookie=true
   oauth1TokenSecretProvider.expirationTime=5 minutes
 
@@ -33,7 +33,7 @@ silhouette {
   # CSRF state item handler settings
   csrfStateItemHandler.cookieName="OAuth2State"
   csrfStateItemHandler.cookiePath="/"
-  csrfStateItemHandler.secureCookie=false // Disabled for testing on localhost without SSL, otherwise cookie couldn't be set
+  csrfStateItemHandler.secureCookie=false // Disabled for testing on localhost without SSL, otherwise cookie could not be set
   csrfStateItemHandler.httpOnlyCookie=true
   csrfStateItemHandler.expirationTime=5 minutes
 
@@ -51,5 +51,5 @@ silhouette {
   facebook.clientSecret = ""
   facebook.redirectURL = ${?FACEBOOK_CLIENT_SECRET}
   facebook.clientSecret = ${?API_CLIENT_SECRET}
-  facebook.scope = "public_profile,user_friends,user_events,user_posts,email,user_age_range,user_link,user_gender,user_likes,user_birthday,user_location,user_photos,manage_pages"
+  facebook.scope = "email,default,user_friends,user_gender,user_link,user_posts"
 }

--- a/dataplug/app/com/hubofallthings/dataplug/apiInterfaces/DataPlugOptionsCollector.scala
+++ b/dataplug/app/com/hubofallthings/dataplug/apiInterfaces/DataPlugOptionsCollector.scala
@@ -18,8 +18,7 @@ import play.api.libs.ws.WSResponse
 import scala.concurrent.{ ExecutionContext, Future }
 
 trait DataPlugOptionsCollector extends RequestAuthenticator with DataPlugApiEndpointClient {
-  def get(fetchParams: ApiEndpointCall, hatAddress: String, hatClientActor: ActorRef, retrying: Boolean)
-         (implicit ec: ExecutionContext): Future[Seq[ApiEndpointVariantChoice]] = {
+  def get(fetchParams: ApiEndpointCall, hatAddress: String, hatClientActor: ActorRef, retrying: Boolean)(implicit ec: ExecutionContext): Future[Seq[ApiEndpointVariantChoice]] = {
 
     authenticateRequest(fetchParams, hatAddress, refreshToken = retrying).flatMap(buildRequest).flatMap { result =>
       result.status match {
@@ -44,8 +43,7 @@ trait DataPlugOptionsCollector extends RequestAuthenticator with DataPlugApiEndp
     Future.failed(exception)
   }
 
-  protected def unauthorizedResponse(fetchParams: ApiEndpointCall, hatAddress: String, hatClientActor: ActorRef, retrying: Boolean, response: WSResponse)
-                          (implicit ec: ExecutionContext): Future[Seq[ApiEndpointVariantChoice]] = {
+  protected def unauthorizedResponse(fetchParams: ApiEndpointCall, hatAddress: String, hatClientActor: ActorRef, retrying: Boolean, response: WSResponse)(implicit ec: ExecutionContext): Future[Seq[ApiEndpointVariantChoice]] = {
 
     if (!retrying) {
       logger.debug(s"Unauthorized request $fetchParams for $hatAddress - ${response.status}: ${response.body}")


### PR DESCRIPTION
- added api_version field in every record. It will be used in the SHE feed mapper
- added extra permissions on sandbox facebook
- updated the fields of the pages/liked after facebook updated their API
- updated instagram to be compatible with the feed
- Made changes to the core plug to fix disconnect not killing actors and to enable OAuthProviders to handle the disconnect in the 3rd party side if needed. Updated all the plugs, except twitter, to support the new disconnect flow. Also updated some settings to smooth the flow while running locally
- Fix imports
- fixed deprecated imports
- DS-569 changed Scala and SBT versions. Added one new dependency to solve compatibility issues
- Refactored the option collector slightly
- Added protected scope to one method in the OptionsCollector
- Added protected scope to one method in the OptionsCollector
- DSE-705 #comment reduce our FB data request
