### PR TITLE
Fix infinite sync loop

### DIFF
--- a/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookFeedInterface.scala
+++ b/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookFeedInterface.scala
@@ -52,38 +52,49 @@ class FacebookFeedInterface @Inject() (
 
     logger.debug(s"Content is $content")
 
+    val maybeData = (content \ "data").toOption.exists {
+      case data: JsArray => data.value.isEmpty
+      case _             => false
+    }
+
     val maybeNextPage = (content \ "paging" \ "next").asOpt[String]
     val maybeSinceParam = params.pathParameters.get("since")
 
     logger.debug(s"Found possible next page link: $maybeNextPage")
     logger.debug(s"Found possible next since parameter: $maybeSinceParam")
 
-    maybeNextPage.map { nextPage =>
-      logger.debug(s"Found next page link (continuing sync): $nextPage")
+    if (!maybeData) {
+      maybeNextPage.map { nextPage =>
+        logger.debug(s"Found next page link (continuing sync): $nextPage")
 
-      val nextPageUri = Uri(nextPage)
-      val updatedQueryParams = params.queryParameters ++ nextPageUri.query().toMap
+        val nextPageUri = Uri(nextPage)
+        val updatedQueryParams = params.queryParameters ++ nextPageUri.query().toMap
 
-      logger.debug(s"Updated query parameters: $updatedQueryParams")
+        logger.debug(s"Updated query parameters: $updatedQueryParams")
 
-      if (maybeSinceParam.isDefined) {
-        logger.debug("\"Since\" parameter already set, updating query params")
-        params.copy(queryParameters = updatedQueryParams)
-      }
-      else {
-        (content \ "paging" \ "previous").asOpt[String].flatMap { previousPage =>
-          val previousPageUri = Uri(previousPage)
-          previousPageUri.query().get("since").map { sinceParam =>
-            val updatedPathParams = params.pathParameters + ("since" -> sinceParam)
-
-            logger.debug(s"Updating query params and setting 'since': $sinceParam")
-            params.copy(pathParameters = updatedPathParams, queryParameters = updatedQueryParams)
-          }
-        }.getOrElse {
-          logger.warn("Unexpected API behaviour: 'since' not set and it was not possible to extract it from response body")
+        if (maybeSinceParam.isDefined) {
+          logger.debug("\"Since\" parameter already set, updating query params")
           params.copy(queryParameters = updatedQueryParams)
         }
+        else {
+          (content \ "paging" \ "previous").asOpt[String].flatMap { previousPage =>
+            val previousPageUri = Uri(previousPage)
+            previousPageUri.query().get("since").map { sinceParam =>
+              val updatedPathParams = params.pathParameters + ("since" -> sinceParam)
+
+              logger.debug(s"Updating query params and setting 'since': $sinceParam")
+              params.copy(pathParameters = updatedPathParams, queryParameters = updatedQueryParams)
+            }
+          }.getOrElse {
+            logger.warn("Unexpected API behaviour: 'since' not set and it was not possible to extract it from response body")
+            params.copy(queryParameters = updatedQueryParams)
+          }
+        }
       }
+    }
+    else {
+      logger.debug(s"No Data: $maybeData")
+      None
     }
   }
 


### PR DESCRIPTION
A recent change to Facebook API caused an infinite syncing loop for all active FB accounts. This PR fixes the issue but is NOT addressing any clean up of the database. 

Added check to verify data object is not empty before the pagination logic