### PR TITLE
DSE-956 resolve facebook syncing issues. Update to v9.0 and remove ev…

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Description
+Please add a description of this PR. Descriptions make reasoning easier during the code review
+and also help produce the changelog.
+
+## AC
+Please fill in the ac
+
+## Source
+Please link the Jira ticket here
+
+## Type
+- [ ] Bug Fix
+- [ ] Feature Addition
+- [ ] Refactor
+- [ ] HotFix
+
+## Checklist
+- [ ] tested locally
+- [ ] added new dependencies
+- [ ] updated the docs
+- [ ] added a test

--- a/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookEventInterface.scala
+++ b/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookEventInterface.scala
@@ -22,6 +22,7 @@ import com.hubofallthings.dataplug.utils.{ AuthenticatedHatClient, FutureTransfo
 import com.hubofallthings.dataplugFacebook.models.FacebookEvent
 import com.mohiva.play.silhouette.api.repositories.AuthInfoRepository
 import com.hubofallthings.dataplugFacebook.apiInterfaces.authProviders._
+import org.joda.time.DateTime
 import play.api.Logger
 import play.api.libs.json._
 import play.api.libs.ws.WSClient
@@ -93,33 +94,15 @@ class FacebookEventInterface @Inject() (
   }
 
   def buildNextSync(content: JsValue, params: ApiEndpointCall): ApiEndpointCall = {
-    logger.debug(s"Building next sync...")
-
-    val maybeSinceParam = params.pathParameters.get("since")
-    val updatedQueryParams = params.queryParameters - "after"
+    val updatedQueryParams = params.queryParameters - "__paging_token" - "access_token" - "__previous"
 
     logger.debug(s"Updated query parameters: $updatedQueryParams")
 
-    maybeSinceParam.map { sinceParam =>
-      logger.debug(s"Building next sync parameters $updatedQueryParams with 'since': $sinceParam")
-      params.copy(pathParameters = params.pathParameters - "since", queryParameters = updatedQueryParams + ("since" -> sinceParam))
-    }.getOrElse {
-      logger.debug("'Since' parameter not found (likely no continuation runs), setting one now")
-
-      val maybeNewSinceParam = for {
-        dataArray <- (content \ "data").asOpt[JsArray]
-        headItem <- dataArray.value.headOption
-        latestUpdateTime <- (headItem \ "start_time").asOpt[String]
-      } yield latestUpdateTime
-
-      maybeNewSinceParam.map { newSinceParam =>
-        logger.debug(s"Building next sync parameters $updatedQueryParams with 'since': $newSinceParam")
-        params.copy(queryParameters = updatedQueryParams + ("since" -> newSinceParam))
-      }.getOrElse {
-        logger.warn("Could not extract latest event update time,'since' field is not set. Was the events list empty?")
-        params
-      }
-    }
+    val sinceParameter = DateTime.now().getMillis / 1000
+    val untilParameter = DateTime.now().plusDays(2).getMillis / 1000
+    params.copy(
+      pathParameters = params.pathParameters - "since",
+      queryParameters = updatedQueryParams + ("since" -> sinceParameter.toString) + ("until" -> untilParameter.toString))
   }
 
   override protected def processResults(
@@ -161,7 +144,7 @@ class FacebookEventInterface @Inject() (
 
 object FacebookEventInterface {
   val defaultApiEndpoint = ApiEndpointCall(
-    "https://graph.facebook.com/v5.0",
+    "https://graph.facebook.com/v9.0",
     "/me/events",
     ApiEndpointMethod.Get("Get"),
     Map(),

--- a/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookEventInterface.scala
+++ b/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookEventInterface.scala
@@ -22,6 +22,7 @@ import com.hubofallthings.dataplug.utils.{ AuthenticatedHatClient, FutureTransfo
 import com.hubofallthings.dataplugFacebook.models.FacebookEvent
 import com.mohiva.play.silhouette.api.repositories.AuthInfoRepository
 import com.hubofallthings.dataplugFacebook.apiInterfaces.authProviders._
+import com.typesafe.config.ConfigFactory
 import org.joda.time.DateTime
 import play.api.Logger
 import play.api.libs.json._
@@ -143,8 +144,9 @@ class FacebookEventInterface @Inject() (
 }
 
 object FacebookEventInterface {
+  val baseApiUrl = ConfigFactory.load.getString("service.baseApiUrl")
   val defaultApiEndpoint = ApiEndpointCall(
-    "https://graph.facebook.com/v9.0",
+    baseApiUrl,
     "/me/events",
     ApiEndpointMethod.Get("Get"),
     Map(),

--- a/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookFeedInterface.scala
+++ b/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookFeedInterface.scala
@@ -22,6 +22,7 @@ import com.hubofallthings.dataplug.utils.{ AuthenticatedHatClient, FutureTransfo
 import com.hubofallthings.dataplugFacebook.models.FacebookPost
 import com.mohiva.play.silhouette.api.repositories.AuthInfoRepository
 import com.hubofallthings.dataplugFacebook.apiInterfaces.authProviders._
+import com.typesafe.config.ConfigFactory
 import org.joda.time.DateTime
 import play.api.Logger
 import play.api.libs.json._
@@ -150,8 +151,9 @@ class FacebookFeedInterface @Inject() (
 }
 
 object FacebookFeedInterface {
+  val baseApiUrl = ConfigFactory.load.getString("service.baseApiUrl")
   val defaultApiEndpoint = ApiEndpointCall(
-    "https://graph.facebook.com/v9.0",
+    baseApiUrl,
     "/me/feed",
     ApiEndpointMethod.Get("Get"),
     Map(),

--- a/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookFeedInterface.scala
+++ b/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookFeedInterface.scala
@@ -22,6 +22,7 @@ import com.hubofallthings.dataplug.utils.{ AuthenticatedHatClient, FutureTransfo
 import com.hubofallthings.dataplugFacebook.models.FacebookPost
 import com.mohiva.play.silhouette.api.repositories.AuthInfoRepository
 import com.hubofallthings.dataplugFacebook.apiInterfaces.authProviders._
+import org.joda.time.DateTime
 import play.api.Logger
 import play.api.libs.json._
 import play.api.libs.ws.WSClient
@@ -101,27 +102,15 @@ class FacebookFeedInterface @Inject() (
   def buildNextSync(content: JsValue, params: ApiEndpointCall): ApiEndpointCall = {
     logger.debug(s"Building next sync...")
 
-    val maybeSinceParam = params.pathParameters.get("since")
-    val updatedQueryParams = params.queryParameters - "__paging_token" - "until" - "access_token"
+    val updatedQueryParams = params.queryParameters - "__paging_token" - "access_token" - "__previous"
 
     logger.debug(s"Updated query parameters: $updatedQueryParams")
 
-    maybeSinceParam.map { sinceParameter =>
-      logger.debug(s"Building next sync parameters $updatedQueryParams with 'since': $sinceParameter")
-      params.copy(pathParameters = params.pathParameters - "since", queryParameters = updatedQueryParams + ("since" -> sinceParameter))
-    }.getOrElse {
-      val maybePreviousPage = (content \ "paging" \ "previous").asOpt[String]
-
-      logger.debug("'Since' parameter not found (likely no continuation runs), setting one now")
-      maybePreviousPage.flatMap { previousPage =>
-        Uri(previousPage).query().get("since").map { newSinceParam =>
-          params.copy(queryParameters = params.queryParameters + ("since" -> newSinceParam))
-        }
-      }.getOrElse {
-        logger.warn("Could not extract previous page 'since' parameter so the new value is not set. Was the feed list empty?")
-        params
-      }
-    }
+    val sinceParameter = DateTime.now().getMillis / 1000
+    val untilParameter = DateTime.now().plusDays(2).getMillis / 1000
+    params.copy(
+      pathParameters = params.pathParameters - "since",
+      queryParameters = updatedQueryParams + ("since" -> sinceParameter.toString) + ("until" -> untilParameter.toString))
   }
 
   override protected def processResults(
@@ -162,7 +151,7 @@ class FacebookFeedInterface @Inject() (
 
 object FacebookFeedInterface {
   val defaultApiEndpoint = ApiEndpointCall(
-    "https://graph.facebook.com/v5.0",
+    "https://graph.facebook.com/v9.0",
     "/me/feed",
     ApiEndpointMethod.Get("Get"),
     Map(),

--- a/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookFeedUploadInterface.scala
+++ b/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookFeedUploadInterface.scala
@@ -94,7 +94,7 @@ class FacebookFeedUploadInterface @Inject() (
 
 object FacebookFeedUploadInterface {
   val defaultApiEndpoint = ApiEndpointCall(
-    "https://graph.facebook.com/v5.0",
+    "https://graph.facebook.com/v9.0",
     "/me/feed",
     ApiEndpointMethod.Post("Post", ""),
     Map(),
@@ -103,7 +103,7 @@ object FacebookFeedUploadInterface {
     Some(Map()))
 
   val photoUploadApiEndpoint = ApiEndpointCall(
-    "https://graph.facebook.com/v5.0",
+    "https://graph.facebook.com/v9.0",
     "/me/photos",
     ApiEndpointMethod.Post("Post", ""),
     Map(),
@@ -112,7 +112,7 @@ object FacebookFeedUploadInterface {
     Some(Map()))
 
   val deleteApiEndpoint = ApiEndpointCall(
-    "https://graph.facebook.com/v5.0",
+    "https://graph.facebook.com/v9.0",
     "/[post-id]",
     ApiEndpointMethod.Delete("Delete"),
     Map(),

--- a/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookFeedUploadInterface.scala
+++ b/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookFeedUploadInterface.scala
@@ -18,6 +18,7 @@ import com.hubofallthings.dataplug.apiInterfaces.models.{ ApiEndpointCall, ApiEn
 import com.hubofallthings.dataplug.services.UserService
 import com.hubofallthings.dataplug.utils.Mailer
 import com.hubofallthings.dataplugFacebook.models.FacebookFeedUpdate
+import com.typesafe.config.ConfigFactory
 import play.api.Logger
 import play.api.http.Status._
 import play.api.libs.json.Json
@@ -93,8 +94,10 @@ class FacebookFeedUploadInterface @Inject() (
 }
 
 object FacebookFeedUploadInterface {
+  val baseApiUrl = ConfigFactory.load.getString("service.baseApiUrl")
+
   val defaultApiEndpoint = ApiEndpointCall(
-    "https://graph.facebook.com/v9.0",
+    baseApiUrl,
     "/me/feed",
     ApiEndpointMethod.Post("Post", ""),
     Map(),
@@ -103,7 +106,7 @@ object FacebookFeedUploadInterface {
     Some(Map()))
 
   val photoUploadApiEndpoint = ApiEndpointCall(
-    "https://graph.facebook.com/v9.0",
+    baseApiUrl,
     "/me/photos",
     ApiEndpointMethod.Post("Post", ""),
     Map(),
@@ -112,7 +115,7 @@ object FacebookFeedUploadInterface {
     Some(Map()))
 
   val deleteApiEndpoint = ApiEndpointCall(
-    "https://graph.facebook.com/v9.0",
+    baseApiUrl,
     "/[post-id]",
     ApiEndpointMethod.Delete("Delete"),
     Map(),

--- a/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookPostsInterface.scala
+++ b/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookPostsInterface.scala
@@ -21,6 +21,7 @@ import com.hubofallthings.dataplug.utils.{ AuthenticatedHatClient, FutureTransfo
 import com.hubofallthings.dataplugFacebook.models.FacebookPost
 import com.mohiva.play.silhouette.api.repositories.AuthInfoRepository
 import com.hubofallthings.dataplugFacebook.apiInterfaces.authProviders._
+import com.typesafe.config.ConfigFactory
 import org.joda.time.DateTime
 import play.api.Logger
 import play.api.libs.json.{ JsArray, JsObject, JsValue }
@@ -146,8 +147,9 @@ class FacebookPostsInterface @Inject() (
 }
 
 object FacebookPostsInterface {
+  val baseApiUrl = ConfigFactory.load.getString("service.baseApiUrl")
   val defaultApiEndpoint = ApiEndpointCall(
-    "https://graph.facebook.com/v9.0",
+    baseApiUrl,
     "/me/posts",
     ApiEndpointMethod.Get("Get"),
     Map(),

--- a/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookProfileCheck.scala
+++ b/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookProfileCheck.scala
@@ -35,7 +35,7 @@ class FacebookProfileCheck @Inject() (
   protected val logger: Logger = Logger(this.getClass)
 
   val defaultApiEndpoint = ApiEndpointCall(
-    "https://graph.facebook.com/v5.0",
+    "https://graph.facebook.com/v9.0",
     "/me",
     ApiEndpointMethod.Get("Get"),
     Map(),
@@ -66,17 +66,11 @@ class FacebookProfileCheck @Inject() (
       Some(""), Some(""),
       Some(FacebookPostsInterface.defaultApiEndpoint))
 
-    val eventsVariant = ApiEndpointVariant(
-      ApiEndpoint("events", "Facebook events the user has been invited to", None),
-      Some(""), Some(""),
-      Some(FacebookEventInterface.defaultApiEndpoint))
-
     val choices = Seq(
       ApiEndpointVariantChoice("profile", "User's Facebook profile information", active = true, profileVariant),
       ApiEndpointVariantChoice("profile/picture", "User's Facebook profile picture", active = true, profilePictureVariant),
       ApiEndpointVariantChoice("feed", "User's Facebook posts feed", active = true, feedVariant),
-      ApiEndpointVariantChoice("posts", "User's own Facebook posts", active = true, postsVariant),
-      ApiEndpointVariantChoice("events", "Facebook events the user has been invited to", active = true, eventsVariant))
+      ApiEndpointVariantChoice("posts", "User's own Facebook posts", active = true, postsVariant))
 
     choices
   }

--- a/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookProfileCheck.scala
+++ b/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookProfileCheck.scala
@@ -17,6 +17,7 @@ import com.hubofallthings.dataplug.services.UserService
 import com.hubofallthings.dataplug.utils.Mailer
 import com.mohiva.play.silhouette.api.repositories.AuthInfoRepository
 import com.hubofallthings.dataplugFacebook.apiInterfaces.authProviders._
+import com.typesafe.config.ConfigFactory
 import play.api.Logger
 import play.api.libs.json.JsValue
 import play.api.libs.ws.WSClient
@@ -33,9 +34,10 @@ class FacebookProfileCheck @Inject() (
   val namespace: String = "facebook"
   val endpoint: String = "profile"
   protected val logger: Logger = Logger(this.getClass)
+  val baseApiUrl = ConfigFactory.load.getString("service.baseApiUrl")
 
   val defaultApiEndpoint = ApiEndpointCall(
-    "https://graph.facebook.com/v9.0",
+    baseApiUrl,
     "/me",
     ApiEndpointMethod.Get("Get"),
     Map(),

--- a/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookProfileInterface.scala
+++ b/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookProfileInterface.scala
@@ -21,6 +21,7 @@ import com.hubofallthings.dataplug.utils.{ AuthenticatedHatClient, FutureTransfo
 import com.hubofallthings.dataplugFacebook.models.FacebookProfile
 import com.mohiva.play.silhouette.api.repositories.AuthInfoRepository
 import com.hubofallthings.dataplugFacebook.apiInterfaces.authProviders._
+import com.typesafe.config.ConfigFactory
 import org.joda.time.DateTime
 import play.api.Logger
 import play.api.libs.json._
@@ -110,8 +111,9 @@ class FacebookProfileInterface @Inject() (
 }
 
 object FacebookProfileInterface {
+  val baseApiUrl = ConfigFactory.load.getString("service.baseApiUrl")
   val defaultApiEndpoint = ApiEndpointCall(
-    "https://graph.facebook.com/v9.0",
+    baseApiUrl,
     "/me",
     ApiEndpointMethod.Get("Get"),
     Map(),

--- a/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookProfileInterface.scala
+++ b/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookProfileInterface.scala
@@ -111,7 +111,7 @@ class FacebookProfileInterface @Inject() (
 
 object FacebookProfileInterface {
   val defaultApiEndpoint = ApiEndpointCall(
-    "https://graph.facebook.com/v5.0",
+    "https://graph.facebook.com/v9.0",
     "/me",
     ApiEndpointMethod.Get("Get"),
     Map(),

--- a/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookProfilePictureInterface.scala
+++ b/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookProfilePictureInterface.scala
@@ -21,6 +21,7 @@ import com.hubofallthings.dataplug.utils.{ AuthenticatedHatClient, FutureTransfo
 import com.hubofallthings.dataplugFacebook.models.FacebookProfilePicture
 import com.mohiva.play.silhouette.api.repositories.AuthInfoRepository
 import com.hubofallthings.dataplugFacebook.apiInterfaces.authProviders._
+import com.typesafe.config.ConfigFactory
 import play.api.Logger
 import play.api.libs.json._
 import play.api.libs.ws.WSClient
@@ -88,8 +89,9 @@ class FacebookProfilePictureInterface @Inject() (
 }
 
 object FacebookProfilePictureInterface {
+  val baseApiUrl = ConfigFactory.load.getString("service.baseApiUrl")
   val defaultApiEndpoint = ApiEndpointCall(
-    "https://graph.facebook.com/v9.0",
+    baseApiUrl,
     "/me/picture",
     ApiEndpointMethod.Get("Get"),
     Map(),

--- a/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookProfilePictureInterface.scala
+++ b/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookProfilePictureInterface.scala
@@ -89,7 +89,7 @@ class FacebookProfilePictureInterface @Inject() (
 
 object FacebookProfilePictureInterface {
   val defaultApiEndpoint = ApiEndpointCall(
-    "https://graph.facebook.com/v5.0",
+    "https://graph.facebook.com/v9.0",
     "/me/picture",
     ApiEndpointMethod.Get("Get"),
     Map(),

--- a/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookUserLikesInterface.scala
+++ b/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookUserLikesInterface.scala
@@ -22,6 +22,7 @@ import com.hubofallthings.dataplug.utils.{ AuthenticatedHatClient, FutureTransfo
 import com.hubofallthings.dataplugFacebook.models.{ FacebookPost, FacebookUserLikes }
 import com.mohiva.play.silhouette.api.repositories.AuthInfoRepository
 import com.hubofallthings.dataplugFacebook.apiInterfaces.authProviders._
+import org.joda.time.DateTime
 import play.api.Logger
 import play.api.libs.json._
 import play.api.libs.ws.WSClient
@@ -89,29 +90,15 @@ class FacebookUserLikesInterface @Inject() (
   }
 
   def buildNextSync(content: JsValue, params: ApiEndpointCall): ApiEndpointCall = {
-    logger.debug(s"Building next sync...")
-
-    val maybeBeforeParam = params.pathParameters.get("before")
-    val updatedQueryParams = params.queryParameters - "after" - "access_token"
+    val updatedQueryParams = params.queryParameters - "__paging_token" - "access_token" - "__previous"
 
     logger.debug(s"Updated query parameters: $updatedQueryParams")
 
-    maybeBeforeParam.map { beforeParameter =>
-      logger.debug(s"Building next sync parameters $updatedQueryParams with 'before': $beforeParameter")
-      params.copy(pathParameters = params.pathParameters - "before", queryParameters = updatedQueryParams + ("before" -> beforeParameter))
-    }.getOrElse {
-      val maybePreviousPage = (content \ "paging" \ "cursors" \ "before").asOpt[String]
-
-      logger.debug("'Before' parameter not found (likely no continuation runs), setting one now")
-      maybePreviousPage.flatMap { previousPage =>
-        Uri(previousPage).query().get("before").map { newBefore =>
-          params.copy(queryParameters = params.queryParameters + ("before" -> newBefore))
-        }
-      }.getOrElse {
-        logger.warn("Could not extract previous page 'before' parameter so the new value is not set. Was the feed list empty?")
-        params
-      }
-    }
+    val sinceParameter = DateTime.now().getMillis / 1000
+    val untilParameter = DateTime.now().plusDays(2).getMillis / 1000
+    params.copy(
+      pathParameters = params.pathParameters - "since",
+      queryParameters = updatedQueryParams + ("since" -> sinceParameter.toString) + ("until" -> untilParameter.toString))
   }
 
   override protected def processResults(
@@ -173,7 +160,7 @@ class FacebookUserLikesInterface @Inject() (
 
 object FacebookUserLikesInterface {
   val defaultApiEndpoint = ApiEndpointCall(
-    "https://graph.facebook.com/v5.0",
+    "https://graph.facebook.com/v9.0",
     "/me/likes",
     ApiEndpointMethod.Get("Get"),
     Map(),

--- a/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookUserLikesInterface.scala
+++ b/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/FacebookUserLikesInterface.scala
@@ -22,6 +22,7 @@ import com.hubofallthings.dataplug.utils.{ AuthenticatedHatClient, FutureTransfo
 import com.hubofallthings.dataplugFacebook.models.{ FacebookPost, FacebookUserLikes }
 import com.mohiva.play.silhouette.api.repositories.AuthInfoRepository
 import com.hubofallthings.dataplugFacebook.apiInterfaces.authProviders._
+import com.typesafe.config.ConfigFactory
 import org.joda.time.DateTime
 import play.api.Logger
 import play.api.libs.json._
@@ -159,8 +160,9 @@ class FacebookUserLikesInterface @Inject() (
 }
 
 object FacebookUserLikesInterface {
+  val baseApiUrl = ConfigFactory.load.getString("service.baseApiUrl")
   val defaultApiEndpoint = ApiEndpointCall(
-    "https://graph.facebook.com/v9.0",
+    baseApiUrl,
     "/me/likes",
     ApiEndpointMethod.Get("Get"),
     Map(),

--- a/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/authProviders/FacebookProvider.scala
+++ b/dataplug-facebook/app/com/hubofallthings/dataplugFacebook/apiInterfaces/authProviders/FacebookProvider.scala
@@ -141,6 +141,6 @@ object FacebookProvider {
    * The Uber constants.
    */
   val ID = "facebook"
-  val API = "https://graph.facebook.com/v5.0/me?fields=name,first_name,last_name,picture,email&return_ssl_resources=1&access_token=%s"
+  val API = "https://graph.facebook.com/v9.0/me?fields=name,first_name,last_name,picture,email&return_ssl_resources=1&access_token=%s"
 }
 

--- a/dataplug-facebook/conf/application.conf
+++ b/dataplug-facebook/conf/application.conf
@@ -45,6 +45,7 @@ service {
   provider = "facebook"
   scheme = "https://"
   address = "facebook.dataswift.io"
+  baseApiUrl = "https://graph.facebook.com/v9.0"
   secure = true
   chooseVariants = false
   hatCredentials {

--- a/dataplug-facebook/conf/evolutions/dataplug.sql
+++ b/dataplug-facebook/conf/evolutions/dataplug.sql
@@ -130,3 +130,9 @@ UPDATE dataplug_user
 SET endpoint_configuration = jsonb_set(endpoint_configuration, '{queryParameters,fields}', '"id,caption,created_time,description,from,full_picture,icon,link,is_instagram_eligible,message,message_tags,name,object_id,permalink_url,place,shares,status_type,type,updated_time,with_tags"')
 WHERE dataplug_user.dataplug_endpoint = 'posts';
 
+--changeset dataplugFacebook:removeUserEventsEndpoint context:data
+
+DELETE FROM dataplug_user_status WHERE dataplug_endpoint = 'events';
+DELETE FROM dataplug_user WHERE dataplug_endpoint = 'events';
+DELETE FROM dataplug_endpoint WHERE name = 'events';
+


### PR DESCRIPTION
## Description
* resolve facebook syncing issues 
* Update to v9.0 FB GraphQL API
* remove user events. The user_event scope was removed from fb, as a result we can no longer have access to user's events

## AC
Revert data plug behaviour as it was before. Syncing only for the new items. No full syncs. Break the infinite loop sync.

## Source
https://dswift.atlassian.net/browse/DSE-956?atlOrigin=eyJpIjoiMTU2ZThiNWI5ZDA4NDk3ZGFkM2QxNmZiMTNmN2JiMjUiLCJwIjoiaiJ9

## Type
- [ ] Bug Fix
- [ ] Feature Addition
- [ ] Refactor
- [x] HotFix

## Checklist
- [x ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
